### PR TITLE
chore: Add group and version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,3 +4,6 @@ plugins {
     alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
 }
+
+group = "com.cardinalblue.kraftshade"
+version = "1.0.0"


### PR DESCRIPTION
For PicCollage app integration, we are using Gradle `composite build` to include this project as a dependency, so we need to provide the group name and version.