### PR TITLE
feat: Automatic pipeline resource release mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ pipeline(windowSurface) {
 
 #### Artistic Effects
 - [ ] CGAColorspaceKraftShader (GPUImageCGAColorspaceFilter)
-- [ ] HalftoneKraftShader (GPUImageHalftoneFilter)
+- [x] HalftoneKraftShader (GPUImageHalftoneFilter)
 - [ ] RGBDilationKraftShader (GPUImageRGBDilationFilter)
 - [ ] SketchKraftShader (GPUImageSketchFilter)
 - [ ] SmoothToonKraftShader (GPUImageSmoothToonFilter)

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/HomeScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/HomeScreen.kt
@@ -80,6 +80,7 @@ enum class Destination(
     ErosionDilationShaderTest("erosion_dilation_shader_test", "Erosion/Dilation Shader Test", screen = { ErosionDilationTestScreen() }),
     LevelsShader("levels_shader", "Levels Shader", screen = { LevelsShaderScreen() }),
     FalseColorShader("false_color_shader", "False Color Shader", screen = { FalseColorShaderScreen() }),
+    PipelineCollection("pipeline_collection", "Pipeline Collection", screen = { PipelineCollectionTestWindow() }),
 }
 
 fun NavHostController.navigate(destination: Destination) {

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/shaders/FalseColorShaderScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/shaders/FalseColorShaderScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.cardinalblue.kraftshade.compose.*
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.FalseColorKraftShader
 import kotlin.random.Random
 

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/shaders/LevelsShaderScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/shaders/LevelsShaderScreen.kt
@@ -13,7 +13,6 @@ import com.cardinalblue.kraftshade.compose.KraftShadeEffectView
 import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
 import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.components.ParameterSlider
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.LevelsKraftShader
 
 @Composable

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/CircularBlurPerformanceTestWindow.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/CircularBlurPerformanceTestWindow.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.unit.dp
 import com.cardinalblue.kraftshade.compose.KraftShadeEffectView
 import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.CircularBlurKraftShader
 import com.cardinalblue.kraftshade.util.DangerousKraftShadeApi
 import com.cardinalblue.kraftshade.util.KraftLogger

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/CircularBlurTestWindow.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/CircularBlurTestWindow.kt
@@ -12,7 +12,6 @@ import com.cardinalblue.kraftshade.compose.KraftShadeEffectView
 import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
 import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.components.ParameterSlider
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.CircularBlurKraftShader
 
 @Composable

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/ColorfulCrosshatchTestScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/ColorfulCrosshatchTestScreen.kt
@@ -12,7 +12,6 @@ import com.cardinalblue.kraftshade.compose.KraftShadeEffectView
 import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
 import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.components.ParameterSlider
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.ColorInvertKraftShader
 import com.cardinalblue.kraftshade.shader.builtin.CrosshatchKraftShader
 import com.cardinalblue.kraftshade.shader.builtin.MultiplyBlendKraftShader

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/CrosshatchTestScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/CrosshatchTestScreen.kt
@@ -12,7 +12,6 @@ import com.cardinalblue.kraftshade.compose.KraftShadeEffectView
 import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
 import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.components.ParameterSlider
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.CrosshatchKraftShader
 
 @Composable

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/KraftShadeAnimatedViewTestWindow.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/KraftShadeAnimatedViewTestWindow.kt
@@ -12,7 +12,6 @@ import com.cardinalblue.kraftshade.compose.KraftShadeAnimatedView
 import com.cardinalblue.kraftshade.compose.rememberKraftShadeAnimatedState
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
 import com.cardinalblue.kraftshade.pipeline.input.bounceBetween
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.SaturationKraftShader
 
 @Composable

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/KraftShadeEffectViewTestWindow.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/KraftShadeEffectViewTestWindow.kt
@@ -18,7 +18,6 @@ import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
 import com.cardinalblue.kraftshade.model.GlMat4
 import com.cardinalblue.kraftshade.model.GlVec2
 import com.cardinalblue.kraftshade.pipeline.input.sampledInput
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.*
 
 @Composable

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/KuwaharaTestWindow.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/KuwaharaTestWindow.kt
@@ -24,7 +24,6 @@ import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
 import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.components.CollapsibleSection
 import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.components.ParameterSlider
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.KuwaharaKraftShader
 
 @Composable

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/PipelineCollectionTestWindow.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/PipelineCollectionTestWindow.kt
@@ -1,0 +1,64 @@
+package com.cardinalblue.kraftshade.demo.ui.screen.view.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import com.cardinalblue.kraftshade.compose.KraftShadeEffectView
+import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
+import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
+import com.cardinalblue.kraftshade.shader.builtin.KuwaharaKraftShader
+
+@Composable
+fun PipelineCollectionTestWindow() {
+    val state = rememberKraftShadeEffectState()
+    var aspectRatio by remember { mutableFloatStateOf(1f) }
+
+    val context = LocalContext.current
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight(0.5f)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            KraftShadeEffectView(
+                modifier = Modifier.aspectRatio(aspectRatio),
+                state = state
+            )
+        }
+
+        Button(onClick = {
+            state.setEffect { windowSurface ->
+                val bitmap = context.loadBitmapFromAsset("sample/cat.jpg")
+                aspectRatio = bitmap.width.toFloat() / bitmap.height
+
+                pipeline(windowSurface) {
+                    val texture = bitmap.asTexture()
+                    serialSteps(
+                        inputTexture = texture,
+                        targetBuffer = windowSurface,
+                    ) {
+                        step(KuwaharaKraftShader()) { shader ->
+                            shader.radius = 10
+                        }
+                    }
+                }
+            }
+        }) {
+            Text("Set Effect")
+        }
+    }
+}

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/ResizeTestScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/ResizeTestScreen.kt
@@ -7,12 +7,10 @@ import androidx.compose.material3.Slider
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.cardinalblue.kraftshade.compose.KraftShadeEffectView
 import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
-import com.cardinalblue.kraftshade.shader.buffer.sampledBitmapTextureProvider
 import com.cardinalblue.kraftshade.shader.builtin.DoNothingKraftShader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/ToonEffectTestWindow.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/view/compose/ToonEffectTestWindow.kt
@@ -12,7 +12,6 @@ import com.cardinalblue.kraftshade.compose.KraftShadeEffectView
 import com.cardinalblue.kraftshade.compose.rememberKraftShadeEffectState
 import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.components.ParameterSlider
 import com.cardinalblue.kraftshade.demo.util.loadBitmapFromAsset
-import com.cardinalblue.kraftshade.shader.buffer.asTexture
 import com.cardinalblue.kraftshade.shader.builtin.ToonKraftShader
 
 @Composable

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/resource/KraftLifecycleOwner.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/resource/KraftLifecycleOwner.kt
@@ -1,0 +1,5 @@
+package com.cardinalblue.kraftshade.resource
+
+interface KraftLifecycleOwner : KraftResource {
+    fun bindResource(resource: KraftResource)
+}

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/resource/KraftResource.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/resource/KraftResource.kt
@@ -1,0 +1,5 @@
+package com.cardinalblue.kraftshade.resource
+
+interface KraftResource {
+    suspend fun delete()
+}

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/resource/KraftResourceSet.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/resource/KraftResourceSet.kt
@@ -1,0 +1,16 @@
+package com.cardinalblue.kraftshade.resource
+
+class KraftResourceSet {
+    private val resources: MutableSet<KraftResource> = mutableSetOf()
+
+    fun add(resource: KraftResource) {
+        resources.add(resource)
+    }
+
+    suspend fun clear() {
+        for (resource in resources) {
+            resource.delete()
+        }
+        resources.clear()
+    }
+}

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/KraftShader.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/KraftShader.kt
@@ -6,6 +6,7 @@ import androidx.annotation.CallSuper
 import com.cardinalblue.kraftshade.OpenGlUtils
 import com.cardinalblue.kraftshade.model.GlSize
 import com.cardinalblue.kraftshade.model.GlSizeF
+import com.cardinalblue.kraftshade.resource.KraftResource
 import com.cardinalblue.kraftshade.shader.buffer.GlBuffer
 import com.cardinalblue.kraftshade.shader.builtin.KraftShaderWithTexelSize
 import com.cardinalblue.kraftshade.shader.util.GlUniformDelegate
@@ -16,7 +17,7 @@ import java.util.LinkedList
 
 typealias GlTask = () -> Unit
 
-abstract class KraftShader : SuspendAutoCloseable {
+abstract class KraftShader : SuspendAutoCloseable, KraftResource {
     var debug: Boolean = false
     var clearColorBeforeDraw: Boolean = true
 
@@ -204,6 +205,11 @@ abstract class KraftShader : SuspendAutoCloseable {
         logger.i("Destroying shader program: ${this::class.simpleName}")
         GLES20.glDeleteProgram(glProgId)
         initialized = false
+    }
+
+    @CallSuper
+    override suspend fun delete() {
+        destroy()
     }
 
     override suspend fun close() {

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/LoadedTexture.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/LoadedTexture.kt
@@ -3,7 +3,9 @@ package com.cardinalblue.kraftshade.shader.buffer
 import android.graphics.Bitmap
 import android.opengl.GLES20
 import android.opengl.GLUtils
+import com.cardinalblue.kraftshade.dsl.BasePipelineSetupScope
 import com.cardinalblue.kraftshade.model.GlSize
+import com.cardinalblue.kraftshade.util.UnboundedKraftResource
 
 class LoadedTexture() : Texture() {
     private var _size: GlSize = GlSize(0, 0)
@@ -20,4 +22,10 @@ class LoadedTexture() : Texture() {
     }
 }
 
-fun Bitmap.asTexture() = LoadedTexture(this)
+/**
+ * You have to handle the release of this texture manually if you use this API. check
+ * [BasePipelineSetupScope.asTexture] for an alternative that automatically releases
+ * the texture when the pipeline is destroyed.
+ */
+@UnboundedKraftResource
+fun Bitmap.asTextureUnbounded() = LoadedTexture(this)

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/TextureBuffer.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/TextureBuffer.kt
@@ -3,12 +3,13 @@ package com.cardinalblue.kraftshade.shader.buffer
 import android.graphics.Bitmap
 import android.opengl.GLES20
 import com.cardinalblue.kraftshade.model.GlSize
+import com.cardinalblue.kraftshade.resource.KraftResource
 import com.cardinalblue.kraftshade.util.KraftLogger
 import com.cardinalblue.kraftshade.withFrameBufferRestored
 
 class TextureBuffer(
     override val size: GlSize
-) : Texture(), GlBuffer {
+) : Texture(), GlBuffer, KraftResource {
     private val logger = KraftLogger("TextureBuffer")
 
     private var bufferId: Int = 0

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/util/UnboundedKraftResource.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/util/UnboundedKraftResource.kt
@@ -1,0 +1,22 @@
+package com.cardinalblue.kraftshade.util
+
+@MustBeDocumented
+@Retention(value = AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.ANNOTATION_CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.LOCAL_VARIABLE,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.TYPEALIAS
+)
+@RequiresOptIn(
+    message = "you have you manually release the resource when you are done with it. you can choose to create the resource in pipeline setup scope using ",
+    level = RequiresOptIn.Level.ERROR
+)
+annotation class UnboundedKraftResource

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/widget/KraftEffectTextureView.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/widget/KraftEffectTextureView.kt
@@ -99,8 +99,13 @@ open class KraftEffectTextureView : KraftTextureView {
             val effect = with(effectExecutionProvider) {
                 provide(windowSurface)
             }
-            this@KraftEffectTextureView.effectExecution = effect
+            val previousEffectExecution = effectExecution
+            effectExecution = effect
             afterSet(this, windowSurface)
+
+            runGlTask {
+                previousEffectExecution?.destroy()
+            }
         }
     }
 


### PR DESCRIPTION
# Description
1. Release previous `EffectExecution` which is basically a pipeline in `KraftEffectTextureView.setEffect`
2. Add `KraftResource`, `KraftResouceSet`, `KraftLifecycleOwner` for handling the resource destroy
    - Currently, all the following classes implements `KraftResource`: `Texture`, `KraftShader`, `Pipeline`, `KraftLifecycleOwner`,  `TextureBuffer`
3. In `BasePipelineSetupScope`, following methods are created to bind textures to the pipeline by default
    - `Bitmap.asTexture()`
    - `sampledBitmapTextureProvider(provider: () -> Bitmap?)`