### PR TITLE
fix: Not recycle resources when switching effects

### DIFF
--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/pipeline/serialization/EffectSerializer.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/pipeline/serialization/EffectSerializer.kt
@@ -151,7 +151,7 @@ class EffectSerializer(private val context: Context, private val size: GlSize) {
         val pipeline = Pipeline(
             glEnv = glEnv,
             bufferPool = TextureBufferPool(size),
-            automaticRecycle = false,
+            automaticBufferRecycle = false,
         )
 
         val target = pipeline.bufferPool[BufferReference(pipeline)]

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/KraftShader.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/KraftShader.kt
@@ -10,6 +10,7 @@ import com.cardinalblue.kraftshade.model.GlVec2
 import com.cardinalblue.kraftshade.model.GlVec3
 import com.cardinalblue.kraftshade.model.GlVec4
 import com.cardinalblue.kraftshade.shader.buffer.GlBuffer
+import com.cardinalblue.kraftshade.shader.buffer.Texture
 import com.cardinalblue.kraftshade.shader.builtin.KraftShaderWithTexelSize
 import com.cardinalblue.kraftshade.shader.util.GlUniformDelegate
 import com.cardinalblue.kraftshade.util.KraftLogger
@@ -34,6 +35,7 @@ abstract class KraftShader : SuspendAutoCloseable {
     protected open var resolution: GlSize by GlUniformDelegate("resolution", required = false)
 
     private val uniformLocationCache = mutableMapOf<String, Int>()
+    private val ownedTextures = mutableSetOf<Texture>()
 
     open val debugName: String = this::class.simpleName ?: "Unknown"
 
@@ -245,16 +247,45 @@ abstract class KraftShader : SuspendAutoCloseable {
         GLES30.glBlendEquation(GLES30.GL_FUNC_ADD)
         GLES30.glBlendFunc(GLES30.GL_SRC_ALPHA, GLES30.GL_ONE_MINUS_SRC_ALPHA)
     }
+    
+    fun trackTexture(texture: Texture) {
+        ownedTextures.add(texture)
+        logger.d("tracking texture: ${texture::class.simpleName} (total: ${ownedTextures.size})")
+    }
 
-    fun destroy() {
-        if (!initialized) return
+    suspend fun destroy(includeTextures: Boolean) {
+        if (!initialized)  return
         logger.i("Destroying shader program: ${this::class.simpleName}")
-        GLES30.glDeleteProgram(glProgId)
-        initialized = false
+        
+        try {
+            // Clear pending tasks to avoid memory leaks
+            synchronized(runOnDrawTasks) {
+                runOnDrawTasks.clear()
+            }
+            
+            // Clear uniform cache
+            uniformLocationCache.clear()
+
+            // Clean up owned textures - call suspend function from a suspend context
+            if (includeTextures) {
+                ownedTextures.forEach { texture -> texture.delete() }
+                ownedTextures.clear()
+            }
+            
+            // Delete OpenGL program
+            if (glProgId != 0) {
+                GLES30.glDeleteProgram(glProgId)
+                glProgId = 0
+            }
+            
+            initialized = false
+        } catch (e: Exception) {
+            logger.e("Error destroying shader ${debugName}: ${e.message}", e)
+        }
     }
 
     override suspend fun close() {
-        destroy()
+        destroy(includeTextures = true)
     }
 
     fun KraftShaderTextureInput.activate() {

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/KraftShaderTextureInput.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/KraftShaderTextureInput.kt
@@ -84,5 +84,9 @@ private class TextureDelegate(
             "invalid input texture"
         }
         texture = value
+        // Track new texture
+        if (value.isValid()) {
+            thisRef.trackTexture(value)
+        }
     }
 }

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/TextureInputKraftShader.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/TextureInputKraftShader.kt
@@ -23,10 +23,39 @@ abstract class TextureInputKraftShader(
         return _inputTexture
     }
 
+    /**
+     * Sets the input texture for this shader.
+     * 
+     * **Important**: This method is expected to be called only once in the shader's lifecycle.
+     * Replacing the texture dynamically could make the previous texture resource untrackable,
+     * and you might forget to call [Texture.delete] on it when it's no longer needed,
+     * potentially causing memory leaks.
+     * 
+     * **For dynamic texture replacement**, use [setInputTexture] with [TextureProvider] instead.
+     * For example, use [sampledBitmapTextureProvider] for dynamically loading [android.graphics.Bitmap]s.
+     * 
+     * @param texture The texture to set as input. This texture will be automatically tracked
+     *                by the shader for proper cleanup when the shader is destroyed.
+     * 
+     * @see setInputTexture
+     * @see com.cardinalblue.kraftshade.shader.buffer.sampledBitmapTextureProvider
+     */
     open fun setInputTexture(texture: Texture) {
         _inputTexture = texture
     }
 
+    /**
+     * Sets the input texture using a [TextureProvider].
+     * 
+     * This is the **recommended approach for dynamic texture replacement**, as the [TextureProvider]
+     * manages the texture lifecycle and can be safely replaced multiple times without causing
+     * memory leaks. The provider will handle resource cleanup automatically.
+     * 
+     * @param texture The texture provider that will supply the texture. Use functions like
+     *                [sampledBitmapTextureProvider] for dynamic content loading.
+     * 
+     * @see sampledBitmapTextureProvider
+     */
     fun setInputTexture(texture: TextureProvider) {
         setInputTexture(texture.provideTexture())
     }

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/ThreeTextureInputKraftShader.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/ThreeTextureInputKraftShader.kt
@@ -40,10 +40,39 @@ abstract class ThreeTextureInputKraftShader(
         return _thirdInputTexture
     }
 
+    /**
+     * Sets the third input texture for this shader.
+     * 
+     * **Important**: This method is expected to be called only once in the shader's lifecycle.
+     * Replacing the texture dynamically could make the previous texture resource untrackable,
+     * and you might forget to call [Texture.delete] on it when it's no longer needed,
+     * potentially causing memory leaks.
+     * 
+     * **For dynamic texture replacement**, use [setThirdInputTexture] with [TextureProvider] instead.
+     * For example, use [sampledBitmapTextureProvider] for dynamically loading [android.graphics.Bitmap]s.
+     * 
+     * @param texture The texture to set as the third input. This texture will be automatically tracked
+     *                by the shader for proper cleanup when the shader is destroyed.
+     * 
+     * @see setThirdInputTexture
+     * @see com.cardinalblue.kraftshade.shader.buffer.sampledBitmapTextureProvider
+     */
     open fun setThirdInputTexture(texture: Texture) {
         this._thirdInputTexture = texture
     }
 
+    /**
+     * Sets the third input texture using a [TextureProvider].
+     * 
+     * This is the **recommended approach for dynamic texture replacement**, as the [TextureProvider]
+     * manages the texture lifecycle and can be safely replaced multiple times without causing
+     * memory leaks. The provider will handle resource cleanup automatically.
+     * 
+     * @param texture The texture provider that will supply the third texture. Use functions like
+     *                [sampledBitmapTextureProvider] for dynamic content loading.
+     * 
+     * @see sampledBitmapTextureProvider
+     */
     fun setThirdInputTexture(texture: TextureProvider) {
         setThirdInputTexture(texture.provideTexture())
     }

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/TwoTextureInputKraftShader.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/TwoTextureInputKraftShader.kt
@@ -38,10 +38,39 @@ abstract class TwoTextureInputKraftShader(
         return _secondInputTexture
     }
 
+    /**
+     * Sets the second input texture for this shader.
+     * 
+     * **Important**: This method is expected to be called only once in the shader's lifecycle.
+     * Replacing the texture dynamically could make the previous texture resource untrackable,
+     * and you might forget to call [Texture.delete] on it when it's no longer needed,
+     * potentially causing memory leaks.
+     * 
+     * **For dynamic texture replacement**, use [setSecondInputTexture] with [TextureProvider] instead.
+     * For example, use [sampledBitmapTextureProvider] for dynamically loading [android.graphics.Bitmap]s.
+     * 
+     * @param texture The texture to set as the second input. This texture will be automatically tracked
+     *                by the shader for proper cleanup when the shader is destroyed.
+     * 
+     * @see setSecondInputTexture
+     * @see com.cardinalblue.kraftshade.shader.buffer.sampledBitmapTextureProvider
+     */
     open fun setSecondInputTexture(texture: Texture) {
         this._secondInputTexture = texture
     }
 
+    /**
+     * Sets the second input texture using a [TextureProvider].
+     * 
+     * This is the **recommended approach for dynamic texture replacement**, as the [TextureProvider]
+     * manages the texture lifecycle and can be safely replaced multiple times without causing
+     * memory leaks. The provider will handle resource cleanup automatically.
+     * 
+     * @param texture The texture provider that will supply the second texture. Use functions like
+     *                [sampledBitmapTextureProvider] for dynamic content loading.
+     * 
+     * @see sampledBitmapTextureProvider
+     */
     fun setSecondInputTexture(texture: TextureProvider) {
         setSecondInputTexture(texture.provideTexture())
     }

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/PixelBuffer.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/PixelBuffer.kt
@@ -40,7 +40,7 @@ class PixelBuffer internal constructor(
         EGL14.eglDestroySurface(glEnv.eglDisplay, pbufferSurface)
     }
 
-    override suspend fun close() {
+    override suspend fun close(deleteRecursively: Boolean) {
         delete()
     }
 

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/Texture.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/Texture.kt
@@ -54,7 +54,7 @@ abstract class Texture private constructor(create: Boolean = true) : SuspendAuto
         textureId = OpenGlUtils.NO_TEXTURE_ID
     }
 
-    override suspend fun close() {
+    override suspend fun close(deleteRecursively: Boolean) {
         delete()
     }
 

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/TextureBuffer.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/TextureBuffer.kt
@@ -57,7 +57,9 @@ class TextureBuffer(
     override suspend fun delete() {
         logger.i("Deleting texture buffer")
         super.delete()
-        GLES30.glDeleteFramebuffers(1, intArrayOf(bufferId), 0)
-        bufferId = -1
+        if (bufferId != -1) {
+            GLES30.glDeleteFramebuffers(1, intArrayOf(bufferId), 0)
+            bufferId = -1
+        }
     }
 }

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/WindowSurfaceBuffer.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/shader/buffer/WindowSurfaceBuffer.kt
@@ -118,7 +118,7 @@ class WindowSurfaceBuffer(
         EGL14.eglDestroySurface(glEnv.eglDisplay, windowSurface)
     }
 
-    override suspend fun close() {
+    override suspend fun close(deleteRecursively: Boolean) {
         delete()
     }
 

--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/util/SuspendAutoCloseable.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/util/SuspendAutoCloseable.kt
@@ -1,13 +1,13 @@
 package com.cardinalblue.kraftshade.util
 
 interface SuspendAutoCloseable {
-    suspend fun close()
+    suspend fun close(deleteRecursively: Boolean = true)
 }
 
-suspend inline fun <T : SuspendAutoCloseable, R> T.use(block: (T) -> R): R {
+suspend inline fun <T : SuspendAutoCloseable, R> T.use(deleteRecursively: Boolean = true, block: (T) -> R): R {
     try {
         return block.invoke(this)
     } finally {
-        close()
+        close(deleteRecursively)
     }
 }


### PR DESCRIPTION
# Description
- keep track of using `Texture` (which use delegation in `KraftShader`) and recycle them when a pipeline is destroyed
- Add document for using setInputTexture in KraftShader