### PR TITLE
Feat demo add traditional view samples

### DIFF
--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/CategoryTitle.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/CategoryTitle.kt
@@ -1,0 +1,22 @@
+package com.cardinalblue.kraftshade.demo.ui.screen
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun CategoryTitle(title: String) {
+    Text(
+        text = title,
+        color = Color.White,
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier
+            .padding(8.dp)
+    )
+}

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/ColumnScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/ColumnScreen.kt
@@ -13,10 +13,11 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun ColumnScreen(
+    modifier: Modifier = Modifier,
     content: @Composable ColumnScope.() -> Unit
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/ComposableSampleScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/ComposableSampleScreen.kt
@@ -1,0 +1,58 @@
+package com.cardinalblue.kraftshade.demo.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ComposableSampleScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        CategoryTitle("Compose Samples")
+        Text(
+            text = "Explore various Kraftshade effects and shaders",
+            color = Color.Gray,
+            fontSize = 14.sp,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        val composeSamples = Destination.entries.filter { it.isComposableSample }
+        val categorizedSamples = composeSamples.groupBy { it.category }
+
+        Category.entries.forEach { category ->
+            val samplesInCategory = categorizedSamples[category] ?: emptyList()
+            if (samplesInCategory.isNotEmpty()) {
+                CategoryTitle(category.displayName)
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier
+                        .height(((samplesInCategory.size / 2 + samplesInCategory.size % 2) * 80).dp)
+                        .padding(bottom = 16.dp)
+                ) {
+                    items(samplesInCategory) { sample ->
+                        GridOptionButton(sample)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/Destination.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/Destination.kt
@@ -1,0 +1,51 @@
+package com.cardinalblue.kraftshade.demo.ui.screen
+
+import androidx.compose.runtime.Composable
+import com.cardinalblue.kraftshade.demo.ui.screen.animation.KraftShadeAnimatedViewTestWindow
+import com.cardinalblue.kraftshade.demo.ui.screen.basic.BasicShaderScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.basic.BlendingExampleScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.blur.CircularBlurPerformanceTestWindow
+import com.cardinalblue.kraftshade.demo.ui.screen.blur.CircularBlurTestWindow
+import com.cardinalblue.kraftshade.demo.ui.screen.color.FalseColorShaderScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.color.LevelsShaderScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.color.LookUpTableShaderTestScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.dsl.KraftBitmapTestScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.effect.ColorfulCrosshatchTestScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.effect.CrosshatchTestScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.effect.EmbossShaderScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.effect.KuwaharaTestWindow
+import com.cardinalblue.kraftshade.demo.ui.screen.effect.ToonEffectTestWindow
+import com.cardinalblue.kraftshade.demo.ui.screen.morphology.ErosionDilationTestScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.view.ResizeTestScreen
+import com.cardinalblue.kraftshade.demo.ui.screen.view.TransparencyTestWindow
+import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.KraftShadeEffectViewTestWindow
+
+enum class Destination(
+    val route: String,
+    val title: String,
+    val isComposableSample: Boolean = true,
+    val category: Category = Category.OTHER,
+    val screen: @Composable () -> Unit,
+) {
+    Home("home", "Home", isComposableSample = false, category = Category.OTHER, screen = { HomeScreen() }),
+    ComposableSamples("compose_samples", "Compose Samples", isComposableSample = false, category = Category.OTHER, screen = { ComposableSampleScreen() }),
+    TraditionalViewSamples("traditional_view_samples", "Traditional View Samples", isComposableSample = false, category = Category.OTHER, screen = { TraditionalViewSampleScreen() }),
+    ResizeTest("resize_test", "Resize Test", category = Category.OTHER, screen = { ResizeTestScreen() }),
+    BasicShader("basic_shader", "Basic Shader", category = Category.BASIC, screen = { BasicShaderScreen() }),
+    BlendingExample("blending_example", "Blending Example", category = Category.BASIC, screen = { BlendingExampleScreen() }),
+    EmbossShader("emboss_shader", "Emboss Shader", category = Category.EFFECTS, screen = { EmbossShaderScreen() }),
+    LookUpTableShader("look_up_table_shader", "Look Up Table Shader", category = Category.COLOR, screen = { LookUpTableShaderTestScreen() }),
+    TransparencyTest("transparency_test", "Transparency Test", category = Category.OTHER, screen = { TransparencyTestWindow() }),
+    KraftShadeAnimatedView("compose_animated", "Compose (animated)", category = Category.OTHER, screen = { KraftShadeAnimatedViewTestWindow() }),
+    KraftShadeEffectView("compose_effect", "Compose (effect)", category = Category.OTHER, screen = { KraftShadeEffectViewTestWindow() }),
+    CrosshatchShader("crosshatch_shader", "Crosshatch Shader", category = Category.EFFECTS, screen = { CrosshatchTestScreen() }),
+    ColorfulCrosshatchShader("colorful_crosshatch_shader", "Colorful Crosshatch Shader", category = Category.EFFECTS, screen = { ColorfulCrosshatchTestScreen() }),
+    KraftBitmap("kraft_bitmap", "Kraft Bitmap", category = Category.OTHER, screen = { KraftBitmapTestScreen() }),
+    CircularBlurPerformance("circular_blur_performance", "Circular Blur Performance", category = Category.BLUR, screen = { CircularBlurPerformanceTestWindow() }),
+    CircularBlur("circular_blur", "Circular Blur", category = Category.BLUR, screen = { CircularBlurTestWindow() }),
+    ToonEffect("toon_effect", "Toon Effect", category = Category.EFFECTS, screen = { ToonEffectTestWindow() }),
+    KuwaharaEffect("kuwahara_effect", "Kuwahara Effect", category = Category.EFFECTS, screen = { KuwaharaTestWindow() }),
+    ErosionDilationShaderTest("erosion_dilation_shader_test", "Erosion/Dilation Shader Test", category = Category.BLUR, screen = { ErosionDilationTestScreen() }),
+    LevelsShader("levels_shader", "Levels Shader", category = Category.COLOR, screen = { LevelsShaderScreen() }),
+    FalseColorShader("false_color_shader", "False Color Shader", category = Category.COLOR, screen = { FalseColorShaderScreen() }),
+}

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/GridOptionButton.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/GridOptionButton.kt
@@ -1,0 +1,35 @@
+package com.cardinalblue.kraftshade.demo.ui.screen
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cardinalblue.kraftshade.demo.util.LocalNavController
+
+@Composable
+fun GridOptionButton(
+    destination: Destination,
+    modifier: Modifier = Modifier,
+) {
+    val navController = LocalNavController.current
+    Card(
+        onClick = { navController.navigate(destination.route) },
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Text(
+            text = destination.title,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            textAlign = TextAlign.Center,
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/HomeScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/HomeScreen.kt
@@ -1,139 +1,26 @@
 package com.cardinalblue.kraftshade.demo.ui.screen
 
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.navigation.NavHostController
-import com.cardinalblue.kraftshade.demo.ui.screen.basic.BasicShaderScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.basic.BlendingExampleScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.dsl.KraftBitmapTestScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.color.FalseColorShaderScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.color.LevelsShaderScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.color.LookUpTableShaderTestScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.effect.EmbossShaderScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.effect.CrosshatchTestScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.effect.ColorfulCrosshatchTestScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.effect.ToonEffectTestWindow
-import com.cardinalblue.kraftshade.demo.ui.screen.effect.KuwaharaTestWindow
-import com.cardinalblue.kraftshade.demo.ui.screen.view.TransparencyTestWindow
-import com.cardinalblue.kraftshade.demo.ui.screen.blur.CircularBlurTestWindow
-import com.cardinalblue.kraftshade.demo.ui.screen.blur.CircularBlurPerformanceTestWindow
-import com.cardinalblue.kraftshade.demo.ui.screen.morphology.ErosionDilationTestScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.animation.KraftShadeAnimatedViewTestWindow
-import com.cardinalblue.kraftshade.demo.ui.screen.view.ResizeTestScreen
-import com.cardinalblue.kraftshade.demo.ui.screen.view.compose.KraftShadeEffectViewTestWindow
-import com.cardinalblue.kraftshade.demo.util.LocalNavController
-
 
 @Composable
 fun HomeScreen() {
-    ColumnScreen {
-        val navController = LocalNavController.current
-        Button(
-            onClick = { navController.navigate(Destination.ComposeSamples.route) },
-            modifier = Modifier.padding(16.dp)
-        ) {
-            Text(text = "Compose Samples", fontSize = 18.sp)
-        }
-        Button(
-            onClick = { navController.navigate(Destination.TraditionalViewSamples.route) },
-            modifier = Modifier.padding(16.dp)
-        ) {
-            Text(text = "Traditional View Samples", fontSize = 18.sp)
-        }
+    ColumnScreen(
+        modifier = Modifier.padding(16.dp)
+    ) {
+        GridOptionButton(Destination.ComposableSamples)
+        GridOptionButton(Destination.TraditionalViewSamples)
     }
 }
 
-@Composable
-fun ComposeSampleScreen() {
-    ColumnScreen {
-        Destination.entries
-            .filter { it.isComposeSample }
-            .forEach {
-                key(it) {
-                    OptionButton(it)
-                }
-            }
-    }
-}
-
-@Composable
-fun TraditionalViewSampleScreen() {
-    ColumnScreen {
-        Text(
-            text = "Traditional View Samples",
-            color = Color.White,
-            fontSize = 24.sp,
-            fontWeight = FontWeight.Bold,
-            modifier = Modifier.padding(16.dp)
-        )
-        Text(
-            text = "Coming soon...",
-            color = Color.Gray,
-            fontSize = 16.sp,
-            modifier = Modifier.padding(16.dp)
-        )
-    }
-}
-
-@Composable
-private fun CategoryTitle(title: String) {
-    Text(
-        text = title,
-        color = Color.White,
-        fontSize = 20.sp,
-        fontWeight = FontWeight.Bold,
-        modifier = Modifier
-            .padding(8.dp)
-    )
-}
-
-@Composable
-private fun OptionButton(
-    destination: Destination,
+enum class Category(
+    val displayName: String
 ) {
-    val navController = LocalNavController.current
-    Button(onClick = { navController.navigate(destination.route) }) {
-        Text(text = destination.title)
-    }
-}
-
-enum class Destination(
-    val route: String,
-    val title: String,
-    val isComposeSample: Boolean = true,
-    val screen: @Composable () -> Unit,
-) {
-    Home("home", "Home", isComposeSample = false, screen = { HomeScreen() }),
-    ComposeSamples("compose_samples", "Compose Samples", isComposeSample = false, screen = { ComposeSampleScreen() }),
-    TraditionalViewSamples("traditional_view_samples", "Traditional View Samples", isComposeSample = false, screen = { TraditionalViewSampleScreen() }),
-    ResizeTest("resize_test", "Resize Test", screen = { ResizeTestScreen() }),
-    BasicShader("basic_shader", "Basic Shader", screen = { BasicShaderScreen() }),
-    BlendingExample("blending_example", "Blending Example", screen = { BlendingExampleScreen() }),
-    EmbossShader("emboss_shader", "Emboss Shader", screen = { EmbossShaderScreen() }),
-    LookUpTableShader("look_up_table_shader", "Look Up Table Shader", screen = { LookUpTableShaderTestScreen() }),
-    TransparencyTest("transparency_test", "Transparency Test", screen = { TransparencyTestWindow() }),
-    KraftShadeAnimatedView("compose_animated", "Compose (animated)", screen = { KraftShadeAnimatedViewTestWindow() }),
-    KraftShadeEffectView("compose_effect", "Compose (effect)", screen = { KraftShadeEffectViewTestWindow() }),
-    CrosshatchShader("crosshatch_shader", "Crosshatch Shader", screen = { CrosshatchTestScreen() }),
-    ColorfulCrosshatchShader("colorful_crosshatch_shader", "Colorful Crosshatch Shader", screen = { ColorfulCrosshatchTestScreen() }),
-    KraftBitmap("kraft_bitmap", "Kraft Bitmap", screen = { KraftBitmapTestScreen() }),
-    CircularBlurPerformance("circular_blur_performance", "Circular Blur Performance", screen = { CircularBlurPerformanceTestWindow() }),
-    CircularBlur("circular_blur", "Circular Blur", screen = { CircularBlurTestWindow() }),
-    ToonEffect("toon_effect", "Toon Effect", screen = { ToonEffectTestWindow() }),
-    KuwaharaEffect("kuwahara_effect", "Kuwahara Effect", screen = { KuwaharaTestWindow() }),
-    ErosionDilationShaderTest("erosion_dilation_shader_test", "Erosion/Dilation Shader Test", screen = { ErosionDilationTestScreen() }),
-    LevelsShader("levels_shader", "Levels Shader", screen = { LevelsShaderScreen() }),
-    FalseColorShader("false_color_shader", "False Color Shader", screen = { FalseColorShaderScreen() }),
-}
-
-fun NavHostController.navigate(destination: Destination) {
-    navigate(destination.route)
+    BASIC("Basic Shaders"),
+    EFFECTS("Effects"),
+    COLOR("Color & Levels"),
+    BLUR("Blur & Morphology"),
+    OTHER("Other")
 }

--- a/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/TraditionalViewSampleScreen.kt
+++ b/demo/src/main/java/com/cardinalblue/kraftshade/demo/ui/screen/TraditionalViewSampleScreen.kt
@@ -1,0 +1,29 @@
+package com.cardinalblue.kraftshade.demo.ui.screen
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun TraditionalViewSampleScreen() {
+    ColumnScreen {
+        Text(
+            text = "Traditional View Samples",
+            color = Color.White,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(16.dp)
+        )
+        Text(
+            text = "Coming soon...",
+            color = Color.Gray,
+            fontSize = 16.sp,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}


### PR DESCRIPTION
# Description
Modify demo app screens and route to make it easier to browse (Please see the following screenshot):
1. add intermediate screens to navigate to compose sample
2. Make the ComposableSampleScreen pretty

<img width="1080" height="2408" alt="Screenshot_20250815_173907" src="https://github.com/user-attachments/assets/6b67730f-750f-4eb1-aeee-8bd8e22a6941" />
<img width="1080" height="2408" alt="Screenshot_20250815_173919" src="https://github.com/user-attachments/assets/8d786fea-2fa6-4db2-8528-905d596476d8" />
