### PR TITLE
fix: should set surfaceTextureListener to null when terminate

### DIFF
--- a/kraft-shade/src/main/java/com/cardinalblue/kraftshade/widget/KraftTextureView.kt
+++ b/kraft-shade/src/main/java/com/cardinalblue/kraftshade/widget/KraftTextureView.kt
@@ -127,6 +127,7 @@ open class KraftTextureView : TextureView, WindowSurfaceBuffer.Listener {
                     glEnv?.execute {
                         windowSurface?.delete()
                         windowSurface = null
+                        surfaceTextureListener = null
                         terminateEnv()
                     }
 


### PR DESCRIPTION
# Description

There's an issue that when a View is being detach and attach to window again and again. If the `surfaceTextureListener` not set to null on `detachFromWindow`, the next attach to window will reuse the previous `surfaceTextureListener` before its being set, but it should use the new one